### PR TITLE
Fix: Remove reference to undefined haloStyle in WeightKnob

### DIFF
--- a/components/WeightKnob.ts
+++ b/components/WeightKnob.ts
@@ -123,8 +123,6 @@ export class WeightKnob extends LitElement {
     // });
 
     return html`
-      <!-- Halo div removed -->
-      <!-- <div id="halo" style=${haloStyle}></div> -->
       <!-- Static SVG elements -->
       ${this.renderStaticSvg()}
       <!-- SVG elements that move, separated to limit redraws -->


### PR DESCRIPTION
This commit resolves a ReferenceError in the WeightKnob component. The error "haloStyle is not defined" occurred because a commented-out HTML line still contained a template expression `${haloStyle}`.

The `haloStyle` constant and its related logic were removed in a previous commit as part of redesigning the knob, but this reference within the comment was missed.

The fix involves deleting the entire commented-out line: `<!-- <div id="halo" style=${haloStyle}></div> -->` from `components/WeightKnob.ts`.