### PR TITLE
feat: Revamp UI elements for a DJ theme and improved layout

### DIFF
--- a/components/DJStyleSelector.ts
+++ b/components/DJStyleSelector.ts
@@ -1,0 +1,80 @@
+import { css, html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { map } from 'lit/directives/map.js';
+
+export interface DJStyleSelectorOption {
+  value: string;
+  label: string;
+}
+
+@customElement('dj-style-selector')
+export class DJStyleSelector extends LitElement {
+  static override styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      gap: 5px;
+      font-family: 'Roboto', sans-serif; /* Example font */
+    }
+    .option {
+      background-color: #333;
+      color: #fff;
+      border: 1px solid #555;
+      border-radius: 4px;
+      padding: 8px 12px;
+      text-align: center;
+      cursor: pointer;
+      transition: background-color 0.2s, box-shadow 0.2s;
+      font-size: 0.9em;
+    }
+    .option:hover {
+      background-color: #444;
+    }
+    .option.selected {
+      background-color: #007bff; /* Bright blue for selected */
+      box-shadow: 0 0 8px #007bff, 0 0 10px #007bff;
+      color: #fff;
+      font-weight: bold;
+    }
+  `;
+
+  @property({ type: Array })
+  options: DJStyleSelectorOption[] = [];
+
+  @property({ type: String })
+  value: string = '';
+
+  private _handleOptionClick(optionValue: string) {
+    this.value = optionValue;
+    this.dispatchEvent(
+      new CustomEvent('change', {
+        detail: this.value,
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  override render() {
+    return html`
+      ${map(
+        this.options,
+        (option) => html`
+          <div
+            class="option ${option.value === this.value ? 'selected' : ''}"
+            @click=${() => this._handleOptionClick(option.value)}
+          >
+            ${option.label}
+          </div>
+        `
+      )}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'dj-style-selector': DJStyleSelector;
+  }
+}

--- a/components/WeightKnob.ts
+++ b/components/WeightKnob.ts
@@ -119,6 +119,10 @@ export class WeightKnob extends LitElement {
       transform: `translate(40px, 40px) rotate(${rot}rad)`,
     });
 
+    const isAutoValue = Math.abs(this.value - 1.0) < 0.001; // Check if value is at the "auto" mark (1.0)
+    const indicatorColor = isAutoValue ? '#00FFFF' : '#FFFFFF'; // Cyan for auto, White otherwise
+    const indicatorStrokeWidth = isAutoValue ? 3.5 : 3; // Thicker for auto
+
     let scale = (this.value / 2) * (MAX_HALO_SCALE - MIN_HALO_SCALE);
     scale += MIN_HALO_SCALE;
     scale += this.audioLevel * HALO_LEVEL_MODIFIER;
@@ -139,25 +143,25 @@ export class WeightKnob extends LitElement {
         @pointerdown=${this.handlePointerDown}
         @wheel=${this.handleWheel}>
         <g style=${dotStyle}>
-          <!-- Changed from circle to a line for the indicator -->
-          <line x1="8" y1="0" x2="23" y2="0" stroke="#FFFFFF" stroke-width="2.5" stroke-linecap="round" />
+          <!-- Indicator line: longer and styled -->
+          <line x1="5" y1="0" x2="25" y2="0" stroke="${indicatorColor}" stroke-width="${indicatorStrokeWidth}" stroke-linecap="round" />
         </g>
-        <!-- The following paths were part of the old knob's value indication, replacing with simpler visual feedback or removing if not needed for DJ aesthetic -->
         <!-- Path for the track -->
         <path
           d=${this.describeArc(40, 40, minRot, maxRot, 34.5)}
           fill="none"
           stroke="#4A4A4A" /* Darker, subtle track for the knob range */
           stroke-opacity="0.7"
-          stroke-width="2.5" /* Slightly thinner */
+          stroke-width="2.5"
           stroke-linecap="round" />
-        <!-- Path for the value fill - might be kept or altered if DJ knobs sometimes have this kind of value ring -->
+        <!-- Path for the value fill - styled with this.color -->
         <path
           d=${this.describeArc(40, 40, minRot, rot, 34.5)}
           fill="none"
-          stroke="#707070" /* Lighter grey for the value arc, but still subtle */
-          stroke-width="2.5" /* Slightly thinner */
-          stroke-linecap="round" />
+          stroke=${this.color || '#707070'} /* Use halo color or default grey */
+          stroke-width="3" /* Slightly thicker value arc */
+          stroke-linecap="round"
+          opacity="0.8" />
       </svg>
     `;
   }
@@ -168,6 +172,24 @@ export class WeightKnob extends LitElement {
     const knobBodyColor = "#282828"; // Dark grey for knob "side"
     const knobTopColorBase = "#303030"; // Base color for the knob top
     const knobTopHighlight = "#383838"; // Subtle highlight for the center of the knob top
+    const tickColor = "#666"; // Color for tick marks
+    const numTicks = 5;
+    const tickLength = 3; // Length of the tick mark
+    const tickRadius = 28; // Radius at which ticks are placed (center of tick)
+
+    const rotationRange = Math.PI * 2 * 0.75;
+    const minRot = -rotationRange / 2 - Math.PI / 2; // Start angle for ticks
+    // const maxRot = rotationRange / 2 - Math.PI / 2; // End angle for ticks (not strictly needed for loop)
+
+    let ticksHtml = '';
+    for (let i = 0; i < numTicks; i++) {
+      const tickAngle = minRot + (i / (numTicks - 1)) * rotationRange;
+      const x1 = 40 + (tickRadius - tickLength / 2) * Math.cos(tickAngle);
+      const y1 = 40 + (tickRadius - tickLength / 2) * Math.sin(tickAngle);
+      const x2 = 40 + (tickRadius + tickLength / 2) * Math.cos(tickAngle);
+      const y2 = 40 + (tickRadius + tickLength / 2) * Math.sin(tickAngle);
+      ticksHtml += `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="${tickColor}" stroke-width="1.5" stroke-linecap="round" />`;
+    }
 
     return html`<svg viewBox="0 0 80 80">
         <defs>
@@ -188,6 +210,8 @@ export class WeightKnob extends LitElement {
         <!-- Knob top surface -->
         <circle cx="40" cy="40" r="25" fill="url(#knobTopGradient)" />
 
+        <!-- Static Tick Marks -->
+        ${svg`${ticksHtml}`}
       </svg>`
   }
 

--- a/index.tsx
+++ b/index.tsx
@@ -18,6 +18,8 @@ import './components/WeightKnob';
 import './components/PromptController';
 import { ToastMessage } from './components/ToastMessage';
 import type { WeightKnob } from './components/WeightKnob';
+import './components/DJStyleSelector';
+import type { DJStyleSelectorOption } from './components/DJStyleSelector';
 
 import type { Prompt, PlaybackState } from './types';
 
@@ -71,7 +73,7 @@ class PromptDjMidi extends LitElement {
       max-width: 1600px;
       height: 100%;
       padding: 8vmin 5vmin;
-      padding-right: 300px; /* Added for fixed panel */
+      padding-right: 240px; /* Added for fixed panel */
       box-sizing: border-box;
     }
     .advanced-settings-panel {
@@ -80,7 +82,7 @@ class PromptDjMidi extends LitElement {
       top: 0;
       height: 100vh;
       overflow-y: auto;
-      width: 300px;
+      width: 240px;
       z-index: 1000;
       background-color: #202020;
       border-radius: 8px;
@@ -103,6 +105,11 @@ class PromptDjMidi extends LitElement {
         font-weight: bold;
         text-align: center;
         color: #fff; /* Ensure labels are white */
+    }
+
+    .advanced-settings-panel .setting weight-knob {
+      width: 100px;
+      margin: 0 auto; /* Center the knob if its container is wider */
     }
  
    .advanced-settings-panel .setting .auto-row,
@@ -189,8 +196,7 @@ class PromptDjMidi extends LitElement {
     }
 
      #main-audio-button {
-       width: 80%;
-       max-width: 150px;
+       width: calc(100% - 40px); /* Adjusts for panel padding */
        height: 40px;
        border-radius: 6px;
        display: flex;
@@ -664,7 +670,10 @@ class PromptDjMidi extends LitElement {
      } else if (target instanceof HTMLInputElement && target.type === 'number') {
         const value = (target as HTMLInputElement).value;
         this.config = { ...this.config, [id]: value === '' ? null : parseFloat(value) };
-     } else { // For select elements
+     } else if (event instanceof CustomEvent && event.detail !== undefined) { // For DJStyleSelector
+        const value = event.detail;
+        this.config = { ...this.config, [id]: value };
+     } else { // For standard HTMLSelectElement
         const value = (target as HTMLSelectElement).value;
         this.config = { ...this.config, [id]: value };
      }
@@ -699,6 +708,8 @@ class PromptDjMidi extends LitElement {
  
      const cfg = this.config;
  
+     const djStyleSelectorOptions = Array.from(scaleMap, ([label, value]) => ({ label, value } as DJStyleSelectorOption));
+
       return html`
         <div id="background" style=${bg}></div>
         <div id="buttons">
@@ -809,11 +820,12 @@ ${this.renderPrompts()}
           </div>
           <div class="setting">
             <label for="scale">Scale</label>
-            <select id="scale" .value=${cfg.scale} @change=${this.handleInputChange}>
-              ${Array.from(scaleMap.entries()).map(([key, value]) => html`
-                <option value=${value}>${key}</option>
-              `)}
-            </select>
+            <dj-style-selector
+              id="scale"
+              .options=${djStyleSelectorOptions}
+              .value=${cfg.scale}
+              @change=${this.handleInputChange}
+            ></dj-style-selector>
           </div>
           <div class="setting checkbox-setting">
             <input


### PR DESCRIPTION
This commit implements several UI enhancements:

1.  **Standardized Knob Sizes:** Knobs in the advanced settings panel are now consistent in size with the main application knobs.
2.  **Reduced Right Panel Width:** The advanced settings panel width has been reduced from 300px to 240px, and the main content area padding adjusted accordingly.
3.  **Fixed Power Button Rendering:** The power button in the right panel has been resized to fit correctly within the narrower panel.
4.  **Redesigned Scale Selector:** Replaced the standard HTML select for musical scale with a custom `dj-style-selector` component, featuring a DJ-themed pill-button design.
5.  **Redesigned Knob Ticks/Indicator:**
    *   Added static tick marks to the `WeightKnob` component.
    *   The knob's indicator line is now more prominent.
    *   The indicator line changes color and thickness when the knob's value is at the typical "auto" position (value of 1.0) for better visual feedback.
    *   The value arc color is now linked to the knob's main color property.

These changes aim to provide a more cohesive and visually appealing DJ-themed interface, as well as improve the layout of the advanced settings panel.