### PR TITLE
fix: Add missing viewport meta tag for mobile responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="./index.css">
     <script src="https://c.webfontfree.com/c.js?f=DS-Digital" type="text/javascript"></script>
     <script type="importmap">


### PR DESCRIPTION
This commit adds the crucial `<meta name="viewport" content="width=device-width, initial-scale=1.0">` tag to `index.html`.

This tag is essential for mobile browsers to correctly interpret the page's intended scale and dimensions, enabling the responsive design to work as expected. Without it, mobile browsers often default to rendering the page as if it were on a desktop screen, ignoring media queries and responsive layouts.