### PR TITLE
refactor: Adjust mobile grid layout for prompt controllers

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -206,17 +206,10 @@ class PromptDjMidi extends LitElement {
 
     @media (max-width: 767px) {
       #grid {
-        grid-template-columns: repeat(2, 1fr);
-        width: 90vmin; /* Adjust width if necessary for better fit */
+        grid-template-columns: 1fr; /* Ensures 1 knob per row */
+        width: 50vw; /* Set width to half viewport width */
         height: auto; /* Adjust height to content if necessary */
-      }
-    }
-
-    @media (max-width: 479px) {
-      #grid {
-        grid-template-columns: repeat(1, 1fr);
-        width: 90vmin; /* Or even 95vmin if 1 column feels too narrow */
-        /* Height remains auto or adjust as needed */
+        margin: 0 auto; /* Center the grid */
       }
     }
  


### PR DESCRIPTION
This commit refines the mobile layout of the prompt controller grid (#grid) based on your feedback:

- Prompt Controller Grid:
  - On mobile screens (<= 767px wide), the grid now displays exactly one prompt controller per row (`grid-template-columns: 1fr`).
  - The width of the grid on these screens has been set to `50vw`.
  - The grid is now centered horizontally (`margin: 0 auto;`) within its parent container on mobile.

These changes aim to address the issue of a garbled main screen on mobile devices by providing a cleaner, more focused layout for the prompt controllers, and ensuring the main active area occupies half the viewport width as requested.