### PR TITLE
Fix build error by removing extraneous line in index.tsx

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1644,5 +1644,3 @@ ${this.renderPrompts()}
   }
  
   main(document.body);
-
-[end of index.tsx]


### PR DESCRIPTION
The build was failing due to a line `[end of index.tsx]` at the end of the `index.tsx` file. This commit removes that line.