### PR TITLE
feat: Smooth background gradient changes for programmatic updates

### DIFF
--- a/index.css
+++ b/index.css
@@ -205,3 +205,18 @@ body.dragging * {
 #buttons .seed-controls.seed-controls-hoverable input {
     transition: opacity 0.3s ease-in-out; /* so they fade smoothly with the container */
 }
+
+.background-light {
+  position: absolute;
+  width: 15vmin;
+  height: 15vmin;
+  border-radius: 50%;
+  mix-blend-mode: lighten;
+  pointer-events: none;
+  /* The translate(-50%, -50%) part of transform is static for centering */
+  /* We will apply dynamic scale via inline style, so the full transform is set inline. */
+  /* However, if only scale was dynamic, we could have set translate here. */
+  /* For transitions, it's generally good to transition specific properties like opacity and transform (or scale). */
+  transition: opacity 0.4s ease-out, transform 0.4s ease-out;
+  will-change: opacity, transform; /* Hint to the browser for optimization */
+}

--- a/types.ts
+++ b/types.ts
@@ -10,6 +10,7 @@ export interface Prompt {
   color: string;
   isAutoFlowing?: boolean;
   activatedFromZero?: boolean;
+  backgroundDisplayWeight?: number;
 }
 
 export interface ControlChange {


### PR DESCRIPTION
This commit introduces a mechanism to smooth the visual transition of background gradients when prompt weights are changed programmatically (e.g., during resets or preset loading). Direct user manipulation of prompt controllers remains responsive with immediate visual feedback.

Changes:
- Added `backgroundDisplayWeight` to the `Prompt` type in `types.ts`.
- Initialized `backgroundDisplayWeight` to match `weight` upon prompt creation, loading from storage/presets, and during resets in `index.tsx`.
- The `makeBackground` method in `PromptDjMidi` now uses `prompt.backgroundDisplayWeight` (falling back to `prompt.weight`) to calculate gradient properties (alpha, stops).
- Implemented an animation loop (`_animateBackgroundWeights`) using `requestAnimationFrame` in `PromptDjMidi`. This loop gradually updates `backgroundDisplayWeight` towards the actual `weight` for each prompt using a smoothing factor.
- Programmatic update paths (e.g., `handlePresetSelectedChange`, `globalFlowTick`) now trigger this animation loop for `backgroundDisplayWeight`.
- For changes originating from direct user interaction with `prompt-controller` components (via `handlePromptChanged`), `backgroundDisplayWeight` is set directly to `weight` to ensure immediate responsiveness, bypassing the new smoothing animation.
- Added cleanup for the new animation frame in `disconnectedCallback`.

This approach addresses the issue where programmatic changes could cause abrupt visual jumps in the background, while preserving the smooth feel of direct user interactions.