### PR TITLE
Refactor(WeightKnob): Further slow down auto-knob animation speed

### DIFF
--- a/components/PromptController.ts
+++ b/components/PromptController.ts
@@ -10,7 +10,7 @@ import type { WeightKnob } from './WeightKnob';
 import type { MidiDispatcher } from '../utils/MidiDispatcher';
 import type { Prompt, ControlChange } from '../types';
 
-const AUTO_ANIMATION_SMOOTHING_FACTOR = 0.02; // For slower animation
+const AUTO_ANIMATION_SMOOTHING_FACTOR = 0.001; // For slower animation
 
 /** A single prompt input associated with a MIDI CC. */
 @customElement('prompt-controller')


### PR DESCRIPTION
Per your feedback, the animation speed for engaging the "Auto" feature on the WeightKnob was still too fast.

This commit updates the `AUTO_ANIMATION_SMOOTHING_FACTOR` in `PromptController.ts` from `0.02` to `0.001` to make the animation significantly slower when the "Auto" button is pressed.