### PR TITLE
Fix: Resize PlayPauseButton to match knob dimensions

### DIFF
--- a/components/PlayPauseButton.ts
+++ b/components/PlayPauseButton.ts
@@ -52,9 +52,9 @@ export class PlayPauseButton extends LitElement {
 
   private renderSvg() {
     return html` <svg
-      width="140"
-      height="140"
-      viewBox="0 -10 140 150"
+      width="80"
+      height="80"
+      viewBox="0 -5.714285714285714 80 85.71428571428571"
       fill="none"
       xmlns="http://www.w3.org/2000/svg">
       <rect


### PR DESCRIPTION
The PlayPauseButton SVG was previously hardcoded to 140x140 pixels, making it appear larger than other UI elements, particularly the control knobs.

This change modifies the PlayPauseButton:
- Sets the SVG width and height attributes to "80".
- Adjusts the viewBox to "0 -5.714285714285714 80 85.71428571428571" to correctly scale the button's internal graphics within the new 80x80 dimensions, maintaining its appearance and aspect ratio.

This brings the PlayPauseButton's size in line with the apparent size of the WeightKnob components, which use an 80x80 viewBox, for a more consistent UI.