### PR TITLE
Refactor: Update play button and knob dimensions to percentages and e…

### DIFF
--- a/components/PlayPauseButton.ts
+++ b/components/PlayPauseButton.ts
@@ -18,8 +18,8 @@ export class PlayPauseButton extends LitElement {
       align-items: center;
       justify-content: center;
       pointer-events: none;
-      width: 80px; /* Changed from 100% to a fixed size */
-      height: 80px; /* Added to ensure square aspect ratio */
+      width: 100%;
+      height: 100%;
     }
     :host(:hover) svg {
       transform: scale(1.2);

--- a/index.tsx
+++ b/index.tsx
@@ -201,7 +201,7 @@ export class PromptDjMidi extends LitElement {
     }
 
     .advanced-settings-panel .setting weight-knob {
-      width: 100px;
+      width: 41.67%;
       margin: 0 auto; 
     }
  
@@ -432,9 +432,10 @@ export class PromptDjMidi extends LitElement {
     }
 
     play-pause-button {
-      width: 100px;
-      height: 100px;
+      width: 41.67%;
+      height: 41.67%;
       margin: 0 auto 15px auto; 
+      align-self: center;
       display: block;
       cursor: pointer;
     }


### PR DESCRIPTION
…nsure centering

Changes made:

- Modified `components/PlayPauseButton.ts`:
  - Set host `width` and `height` to `100%` to allow container styles to dictate size.

- Modified `index.tsx` styles:
  - Updated `play-pause-button` global styles:
    - Changed `width` and `height` from `100px` to `41.67%` (relative to the 240px right panel width).
    - Added `align-self: center` to ensure horizontal centering in the flex layout of the advanced settings panel.
  - Updated `.advanced-settings-panel .setting weight-knob` styles:
    - Changed `width` from `100px` to `41.67%`.
    - `aspect-ratio: 1` on the WeightKnob component ensures its height matches.

These changes ensure that the play button and the knobs in the right panel have the same dimensions, now based on percentages of the panel width. Centering is maintained for both elements.