### PR TITLE
Fix: Center play/pause button icon

### DIFF
--- a/components/PlayPauseButton.ts
+++ b/components/PlayPauseButton.ts
@@ -54,7 +54,7 @@ export class PlayPauseButton extends LitElement {
 
   private renderSvg() {
     return html` <svg
-      viewBox="0 -10 140 150"
+      viewBox="0 0 140 140"
       fill="none"
       xmlns="http://www.w3.org/2000/svg">
       <rect


### PR DESCRIPTION
The play/pause button's icon appeared to lean to the left. This was caused by a non-square viewBox (0 -10 140 150) for the SVG in the PlayPauseButton component.

This commit changes the viewBox to "0 0 140 140", making the coordinate system square and removing the vertical offset. This visually centers the icon within the button element. The button element itself was already correctly centered in its container.