### PR TITLE
Fix: Relocate MediaRecorder methods into PromptDjMidi class

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -2003,6 +2003,116 @@ export class PromptDjMidi extends LitElement {
    private getApiKey() {
      window.open('https://aistudio.google.com/apikey', '_blank');
    }
+  // MediaRecorder methods
+  private async startRecording() {
+    // Ensure audio context and output nodes are ready
+    if (!this.audioContext || !this.outputNode) {
+      console.error('AudioContext or outputNode not initialized. Cannot start recording.');
+      // Attempt to initialize audio if it's not ready (e.g., user clicks record before play)
+      // This assumes `play()` correctly sets up audioContext and outputNode.
+      // Or, consider disabling record button until audio is ready.
+      if (!this.audioReady) {
+         await this.play(); // Try to initialize audio stack via play()
+         if (!this.audioContext || !this.outputNode) {
+            console.error('Failed to initialize audio stack for recording.');
+            this.isRecordingActive = false;
+            this.requestUpdate();
+            return;
+         }
+      }
+    }
+
+    // Initialize MediaStreamDestinationNode if it hasn't been, or if context was recreated
+    if (!this.mediaStreamDestinationNode || this.mediaStreamDestinationNode.context !== this.audioContext) {
+        if (this.audioContext && this.outputNode) {
+            this.mediaStreamDestinationNode = this.audioContext.createMediaStreamDestination();
+            this.outputNode.connect(this.mediaStreamDestinationNode);
+            console.log('Initialized MediaStreamDestinationNode for recording.');
+        } else {
+            console.error('Cannot initialize MediaStreamDestinationNode: AudioContext or outputNode missing.');
+            this.isRecordingActive = false;
+            this.requestUpdate();
+            return;
+        }
+    }
+
+    this.audioStream = this.mediaStreamDestinationNode.stream; // Use the stream from the destination node
+
+    try {
+      const mediaRecorderOptions = {
+        mimeType: 'audio/ogg;codecs=opus',
+        audioBitsPerSecond: 256000
+      };
+
+      if (isOpusPolyfillActive) {
+        this.mediaRecorder = new MediaRecorder(this.audioStream, mediaRecorderOptions, opusWorkerOptions);
+      } else {
+        this.mediaRecorder = new MediaRecorder(this.audioStream, mediaRecorderOptions);
+      }
+
+      this.audioChunks = []; // Clear previous chunks
+
+      this.mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          this.audioChunks.push(event.data);
+        }
+      };
+
+      this.mediaRecorder.onstop = () => {
+        const audioBlob = new Blob(this.audioChunks, { type: 'audio/ogg' });
+        const url = URL.createObjectURL(audioBlob);
+        const a = document.createElement('a');
+        document.body.appendChild(a);
+        a.style.display = 'none';
+        a.href = url;
+        a.download = 'recording.ogg';
+        a.click();
+        window.URL.revokeObjectURL(url);
+        document.body.removeChild(a);
+
+        this.audioChunks = []; // Clear chunks for next recording
+        this.isRecordingActive = false;
+
+        // DO NOT stop tracks on this.audioStream from MediaStreamAudioDestinationNode
+        // this.audioStream = null; // We can nullify our reference, but the node's stream persists.
+
+        this.requestUpdate();
+      };
+
+      this.mediaRecorder.start();
+      this.isRecordingActive = true;
+    } catch (err) {
+      console.error('Failed to start recording with MediaStreamDestination:', err);
+      this.isRecordingActive = false;
+    }
+    this.requestUpdate(); // Ensure UI updates with isRecordingActive
+  }
+
+  private stopRecording() {
+    if (this.mediaRecorder && this.isRecordingActive) {
+      this.mediaRecorder.stop();
+      // isRecordingActive will be set to false in onstop
+    } else {
+      console.log('MediaRecorder not active or not initialized for stopping.');
+      // Ensure UI consistency if called unexpectedly
+      if (this.isRecordingActive) {
+        this.isRecordingActive = false;
+        this.requestUpdate();
+      }
+    }
+  }
+
+  private async handleRecordClick() {
+    if (this.isRecordingActive) {
+      // stopRecording is synchronous in its current implementation
+      // but good practice if it might become async
+      this.stopRecording();
+    } else {
+      await this.startRecording();
+    }
+    // isRecordingActive state is updated within startRecording/stopRecording's onstop
+    // and because it's a @state property, Lit should handle re-rendering the record-button.
+  }
     private resetAll() {
       this.config = { ...PromptDjMidi.INITIAL_CONFIG };
  


### PR DESCRIPTION
The `startRecording`, `stopRecording`, and `handleRecordClick` methods were previously defined outside the `PromptDjMidi` class, leading to a syntax error during the build process ("Expected ";" but found "async"").

This commit moves these method definitions inside the `PromptDjMidi` class body, correcting the syntax and allowing the build to proceed.